### PR TITLE
Add support for toggling DataDog API endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.4 (November 30, 2022)
+
+CHANGES:
+
+* Added a plugin setting for toggling between public (datadoghq.com) and govcloud (ddog-gov.com) API endpoints.
+
 ## 0.0.3 (May 18, 2022)
 
 CHANGES:

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The following settings are available for the DataDog plugin:
 
 |Setting|Description|Required|Default|
 |---|---|---|---|
-|API Key |The generated DataDog API key used to authenticate to the DataDog REST API |  Yes |n/a |
+| API Endpoint | The API endpoint used for fetching instance data | No | Public (datadoghq.com) |
+| API Key |The generated DataDog API key used to authenticate to the DataDog REST API |  Yes |n/a |
 | Application Key | The generated DataDog Application key used to authenticate to the DataDog REST API | Yes |n/a |
 | Environments | This toggles the visibility of the tab based upon the Morpheus environment the instance is in. Multiple environments are supported by adding multiple comma separated environments in the text box.| No| any|
 | Groups | This toggles the visibility of the tab based upon the Morpheus group the instance is in. Multiple groups are supported by adding multiple comma separated groups in the text box.| No|any |

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
 group = 'com.morpheusdata'
-version = '0.0.3'
+version = '0.0.4'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/src/main/groovy/com/morpheusdata/tab/DataDogAPIEndpointOptionSourceProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogAPIEndpointOptionSourceProvider.groovy
@@ -1,0 +1,51 @@
+package com.morpheusdata.tab
+
+import com.morpheusdata.core.MorpheusContext
+import com.morpheusdata.core.Plugin
+import com.morpheusdata.model.*
+import groovy.util.logging.Slf4j
+import com.morpheusdata.core.OptionSourceProvider
+
+@Slf4j
+class DataDogAPIEndpointOptionSourceProvider implements OptionSourceProvider {
+
+	Plugin plugin
+	MorpheusContext morpheusContext
+
+	DataDogAPIEndpointOptionSourceProvider(Plugin plugin, MorpheusContext context) {
+		this.plugin = plugin
+		this.morpheusContext = context
+	}
+
+	@Override
+	MorpheusContext getMorpheus() {
+		return this.morpheusContext
+	}
+
+	@Override
+	Plugin getPlugin() {
+		return this.plugin
+	}
+
+	@Override
+	String getCode() {
+		return 'datadog-tab-plugin'
+	}
+
+	@Override
+	String getName() {
+		return 'DataDog API Endpoints'
+	}
+
+	@Override
+	List<String> getMethodNames() {
+		return new ArrayList<String>(['datadogApiEndpoints'])
+	}
+
+	List datadogApiEndpoints(args) {
+		[
+				[name: 'Public (datadoghq.com)', value: 'datadoghq.com'],
+				[name: 'GovCloud (ddog-gov.com)', value: 'ddog-gov.com']
+		]
+	}
+}

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabPlugin.groovy
@@ -18,6 +18,9 @@ class DataDogTabPlugin extends Plugin {
 	void initialize() {
 		DataDogTabProvider dataDogTabProvider = new DataDogTabProvider(this, morpheus)
 		this.pluginProviders.put(dataDogTabProvider.code, dataDogTabProvider)
+		def optionSourceProvider = new DataDogAPIEndpointOptionSourceProvider(this, morpheus)
+        this.pluginProviders.put(optionSourceProvider.code, optionSourceProvider)
+
 		this.setName("DataDog Tab Plugin")
 		this.setDescription("Instance tab plugin displaying DataDog data")
 		this.setAuthor("Martez Reed")
@@ -27,10 +30,23 @@ class DataDogTabPlugin extends Plugin {
 		// Plugin settings the are used to configure the behavior of the plugin
 		// https://developer.morpheusdata.com/api/com/morpheusdata/model/OptionType.html
 		this.settings << new OptionType(
+			name: 'API Endpoint',
+			code: 'datadog-plugin-api-endpoint',
+			fieldName: 'ddApiEndpoint',
+			optionSource: 'datadogApiEndpoints',
+			defaultValue: 'datadoghq.com',
+			displayOrder: 0,
+			fieldLabel: 'API Endpoint',
+			helpText: 'The DataDog API endpoint',
+			required: true,
+			inputType: OptionType.InputType.SELECT
+		)
+
+		this.settings << new OptionType(
 			name: 'API Key',
 			code: 'datadog-plugin-api-key',
 			fieldName: 'ddApiKey',
-			displayOrder: 0,
+			displayOrder: 1,
 			fieldLabel: 'API Key',
 			helpText: 'The DataDog API key',
 			required: true,
@@ -41,7 +57,7 @@ class DataDogTabPlugin extends Plugin {
 			name: 'Application Key',
 			code: 'datadog-plugin-application-key',
 			fieldName: 'ddAppKey',
-			displayOrder: 1,
+			displayOrder: 2,
 			fieldLabel: 'Application Key',
 			helpText: 'The DataDog Application key',
 			required: true,
@@ -53,7 +69,7 @@ class DataDogTabPlugin extends Plugin {
 			code: 'datadog-plugin-environments-field',
 			fieldName: 'environmentVisibilityField',
 			defaultValue: 'any',
-			displayOrder: 2,
+			displayOrder: 3,
 			fieldLabel: 'Environments',
 			fieldGroup: 'Visibility Settings',
 			helpText: 'List of the names of the Morpheus environments the tab is visible (i.e. - production,qa,dev)',
@@ -66,7 +82,7 @@ class DataDogTabPlugin extends Plugin {
 			code: 'datadog-plugin-groups-field',
 			fieldName: 'groupVisibilityField',
 			defaultValue: 'any',
-			displayOrder: 3,
+			displayOrder: 4,
 			fieldLabel: 'Groups',
 			fieldGroup: 'Visibility Settings',
 			helpText: 'List of the names of the Morpheus groups the tab is visible (i.e. - devs,admins,security)',
@@ -79,7 +95,7 @@ class DataDogTabPlugin extends Plugin {
 			code: 'datadog-plugin-tags-field',
 			fieldName: 'tagVisibilityField',
 			defaultValue: 'datadog',
-			displayOrder: 3,
+			displayOrder: 5,
 			fieldLabel: 'Tags',
 			fieldGroup: 'Visibility Settings',
 			helpText: 'List of the names of the Morpheus tags the tab is visible (i.e. - datadog,monitoring,observability)',

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
@@ -84,7 +84,8 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 			// The payload using the API and Application key from the plugin settings.
 			// https://docs.datadoghq.com/api/latest/hosts/#get-all-hosts-for-your-organization
 			def normalizedInstanceName = instance.name.toLowerCase()
-			def results = dataDogAPI.callApi("https://api.datadoghq.com", "api/v1/hosts?filter=host:${normalizedInstanceName}", "", "", new RestApiUtil.RestOptions(headers:['Content-Type':'application/json','DD-API-KEY':settingsJson.ddApiKey,'DD-APPLICATION-KEY':settingsJson.ddAppKey], ignoreSSL: false), 'GET')
+			def apiURL = "https://api.${settingsJson.ddApiEndpoint}"
+			def results = dataDogAPI.callApi(apiURL, "api/v1/hosts?filter=host:${normalizedInstanceName}", "", "", new RestApiUtil.RestOptions(headers:['Content-Type':'application/json','DD-API-KEY':settingsJson.ddApiKey,'DD-APPLICATION-KEY':settingsJson.ddAppKey], ignoreSSL: false), 'GET')
 
 			// Check if the API and Application keys have been set for the plugin
 			if (results.success == false){
@@ -106,7 +107,6 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				def baseHost = json.host_list[0]
 				def status = baseHost.up
 				def agentVersion = baseHost.meta.agent_version
-				log.info("DatDog agent checks: ${baseHost.meta.agent_checks}")
 				def checks = 0
 				if (baseHost.meta.agent_checks == null){
 				  checks = 0
@@ -155,6 +155,7 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				dataDogPayload.put("platformDetails", platformDetails)
 				dataDogPayload.put("cpuDetails", cpuDetails)
 				dataDogPayload.put("memoryDetails", memoryDetails)
+				dataDogPayload.put("apiEndpoint", settingsJson.ddApiEndpoint)
 
 				// Set the value of the model object to the HashMap object
 				model.object = dataDogPayload
@@ -269,11 +270,6 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 			){
 				show = true
 			}
-			//log.info("Permission status: ${permissionStatus}")
-			//log.info("Environment status: ${environmentStatus}")
-			//log.info("Group status: ${groupStatus}")
-			//log.info("Tag status: ${tagStatus}")
-			//log.info("Show status: ${show}")
 		}
 		catch(Exception ex) {
           log.info("DataDog Plugin: Error parsing the DataDog plugin settings. Ensure that the plugin settings have been configured.")

--- a/src/main/resources/renderer/hbs/instanceTab.hbs
+++ b/src/main/resources/renderer/hbs/instanceTab.hbs
@@ -15,7 +15,7 @@
                </button>
                <ul class="dropdown-menu">
                   <li>
-                     <a href="https://app.datadoghq.com/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
+                     <a href="https://app.{{apiEndpoint}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
                   </li>
                </ul>
             </div>
@@ -88,7 +88,7 @@
                </button>
                <ul class="dropdown-menu">
                   <li>
-                     <a href="https://app.datadoghq.com/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
+                     <a href="https://app.{{apiEndpoint}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
                   </li>
                </ul>
             </div>


### PR DESCRIPTION
This PR adds support for dynamically configuring the API endpoint used for communication with DataDog to provide support for the GovCloud instance of DataDog.