### PR TITLE
Migrate api endpoint setting to checkbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.0.5 (December 1, 2022)
+
+CHANGES:
+
+* Fixed a bug with the API endpoints option list causing a 500 error to be thrown when the plugin is marked as disabled. The select list for the API endpoint has been migrated to an optional checkbox for the GovCloud API endpoint.
+
 ## 0.0.4 (November 30, 2022)
 
 CHANGES:

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ apply plugin: 'groovy'
 apply plugin: 'maven-publish'
 
 group = 'com.morpheusdata'
-version = '0.0.4'
+version = '0.0.5'
 
 sourceCompatibility = '1.8'
 targetCompatibility = '1.8'

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabPlugin.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabPlugin.groovy
@@ -18,9 +18,6 @@ class DataDogTabPlugin extends Plugin {
 	void initialize() {
 		DataDogTabProvider dataDogTabProvider = new DataDogTabProvider(this, morpheus)
 		this.pluginProviders.put(dataDogTabProvider.code, dataDogTabProvider)
-		def optionSourceProvider = new DataDogAPIEndpointOptionSourceProvider(this, morpheus)
-        this.pluginProviders.put(optionSourceProvider.code, optionSourceProvider)
-
 		this.setName("DataDog Tab Plugin")
 		this.setDescription("Instance tab plugin displaying DataDog data")
 		this.setAuthor("Martez Reed")
@@ -33,13 +30,11 @@ class DataDogTabPlugin extends Plugin {
 			name: 'API Endpoint',
 			code: 'datadog-plugin-api-endpoint',
 			fieldName: 'ddApiEndpoint',
-			optionSource: 'datadogApiEndpoints',
-			defaultValue: 'datadoghq.com',
 			displayOrder: 0,
-			fieldLabel: 'API Endpoint',
-			helpText: 'The DataDog API endpoint',
-			required: true,
-			inputType: OptionType.InputType.SELECT
+			fieldLabel: 'Use GovCloud API Endpoint',
+			helpText: 'Whether to use the GovCloud API endpoint (ddog-gov.com)',
+			required: false,
+			inputType: OptionType.InputType.CHECKBOX
 		)
 
 		this.settings << new OptionType(

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
@@ -84,7 +84,13 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 			// The payload using the API and Application key from the plugin settings.
 			// https://docs.datadoghq.com/api/latest/hosts/#get-all-hosts-for-your-organization
 			def normalizedInstanceName = instance.name.toLowerCase()
-			def apiURL = "https://api.${settingsJson.ddApiEndpoint}"
+			def apiURL
+			if (settingsJson.ddApiEndpoint) {
+				apiURL = "https://api.ddog-gov.com"
+			} else {
+				apiURL = "https://api.datadoghq.com"
+			}
+			log.info("DataDog Plugin: API endpoint ${apiURL}")
 			def results = dataDogAPI.callApi(apiURL, "api/v1/hosts?filter=host:${normalizedInstanceName}", "", "", new RestApiUtil.RestOptions(headers:['Content-Type':'application/json','DD-API-KEY':settingsJson.ddApiKey,'DD-APPLICATION-KEY':settingsJson.ddAppKey], ignoreSSL: false), 'GET')
 
 			// Check if the API and Application keys have been set for the plugin

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
@@ -85,10 +85,13 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 			// https://docs.datadoghq.com/api/latest/hosts/#get-all-hosts-for-your-organization
 			def normalizedInstanceName = instance.name.toLowerCase()
 			def apiURL
+			def appURL
 			if (settingsJson.ddApiEndpoint) {
 				apiURL = "https://api.ddog-gov.com"
+				appURL = "https://app.ddog-gov.com"
 			} else {
 				apiURL = "https://api.datadoghq.com"
+				appURL = "https://app.datadoghq.com"
 			}
 			log.info("DataDog Plugin: API endpoint ${apiURL}")
 			def results = dataDogAPI.callApi(apiURL, "api/v1/hosts?filter=host:${normalizedInstanceName}", "", "", new RestApiUtil.RestOptions(headers:['Content-Type':'application/json','DD-API-KEY':settingsJson.ddApiKey,'DD-APPLICATION-KEY':settingsJson.ddAppKey], ignoreSSL: false), 'GET')
@@ -161,7 +164,7 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				dataDogPayload.put("platformDetails", platformDetails)
 				dataDogPayload.put("cpuDetails", cpuDetails)
 				dataDogPayload.put("memoryDetails", memoryDetails)
-				dataDogPayload.put("apiEndpoint", settingsJson.ddApiEndpoint)
+				dataDogPayload.put("appUrl", appURL)
 
 				// Set the value of the model object to the HashMap object
 				model.object = dataDogPayload

--- a/src/main/resources/renderer/hbs/instanceTab.hbs
+++ b/src/main/resources/renderer/hbs/instanceTab.hbs
@@ -15,7 +15,7 @@
                </button>
                <ul class="dropdown-menu">
                   <li>
-                     <a href="https://app.{{apiEndpoint}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
+                     <a href="{{appUrl}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
                   </li>
                </ul>
             </div>
@@ -88,7 +88,7 @@
                </button>
                <ul class="dropdown-menu">
                   <li>
-                     <a href="https://app.{{apiEndpoint}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
+                     <a href="{{appUrl}}/infrastructure?tags=host%3A{{name}}" target="_blank">Open Dashboard</a>
                   </li>
                </ul>
             </div>


### PR DESCRIPTION
This PR migrates the API endpoint plugin setting from a select list to a checkbox to prevent an issue with a dependency loop in scenarios where the plugin is disabled.