### PR TITLE
Fix for NumberFormatException when listing hosts

### DIFF
--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
@@ -191,7 +191,7 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				        memory = gohaidata.memory.total.replaceAll("[A-Za-z]", "").toLong() 		      // assume value has a unit symbol appended e.g. "34359738368234kB" and convert to Long
 				    }
 				}
-				def formattedMemory = (memory/100000000).round(2)  
+				def formattedMemory = (memory/1000000000).round(2)  
 				def operatingSystem = gohaidata.platform.os
 				def cpuDetails = gohaidata.cpu
 				def platformDetails = gohaidata.platform

--- a/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
+++ b/src/main/groovy/com/morpheusdata/tab/DataDogTabProvider.groovy
@@ -182,6 +182,16 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				def cpuCores = gohaidata.cpu.cpu_cores
 				def logicalProcessors = gohaidata.cpu.cpu_logical_processors
 				def memory = gohaidata.memory.total
+				try {
+					Integer.parseInt(memory)
+				} catch(NumberFormatException ex) {
+				    if(memory.isNumber()) {                                                     
+				        memory = memory.toLong()
+				    } else {                                                                   	 
+				        memory = gohaidata.memory.total.replaceAll("[A-Za-z]", "").toLong() 		      // assume value has a unit symbol appended e.g. "34359738368234kB" and convert to Long
+				    }
+				}
+				def formattedMemory = (memory/100000000).round(2)  
 				def operatingSystem = gohaidata.platform.os
 				def cpuDetails = gohaidata.cpu
 				def platformDetails = gohaidata.platform
@@ -210,7 +220,6 @@ class DataDogTabProvider extends AbstractInstanceTabProvider {
 				dataDogPayload.put("cpuCores", cpuCores)
 				dataDogPayload.put("logicalProcessors", logicalProcessors)
 				dataDogPayload.put("operatingSystem", operatingSystem)
-				def formattedMemory = memory.toInteger()/1000000000
 				dataDogPayload.put("memory", formattedMemory.round(2))
 				dataDogPayload.put("platformDetails", platformDetails)
 				dataDogPayload.put("cpuDetails", cpuDetails)


### PR DESCRIPTION
**Summary:** 
Fixed an issue with the Datadog tab not loading data when converting the total memory value from /api/v1/hosts into an Integer
- (https://github.com/martezr/morpheus-datadog-instance-tab-plugin/commit/d9a5db97f4a7ed05ccb13a34e611f4922c0a1e1f)

**Error examples:**
>2024-04-06_14:55:06.27990 ''[2024-04-06 14:55:06,511] [http-nio-127.0.0.1-8080-exec-7] ERROR c.m.t.DataDogTabProvider - DataDog Plugin: Error in fetching data from DataDog java.lang.NumberFormatException: For input string: "34359738368" 

>2024-04-03_21:15:45.64657 ''[2024-04-03 21:15:45,646] [http-nio-127.0.0.1-8080-exec-9] INFO c.m.c.u.RestApiUtil - calling api: https://api.[datadog-endpoint].com/api/v1/hosts?filter=vmtest064
>
>2024-04-03_21:15:45.64663 ''[2024-04-03 21:15:46,060] [http-nio-127.0.0.1-8080-exec-9] ERROR c.m.t.DataDogTabProvider - DataDog Plugin: Error in fetching data from DataDog java.lang.NumberFormatException: For input string: "3738172kB"

**Original report on the forum:**
https://discuss.morpheusdata.com/t/datadog-plugin-is-calling-api-with-3f-instead-of-before-query-parameter/1764/14